### PR TITLE
Update setup.py to find and install sub-packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-.svn
-.DS_Store
-.pyc
+*.svn
+*.DS_Store
+*.pyc
+build/
+dist/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include nrutils *

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 #
 from distutils.core import setup
+from setuptools import find_packages
 
 #
 setup(name='nrutils',
@@ -9,7 +10,7 @@ setup(name='nrutils',
       description='Python Utilities for Numerical Reltivity Data Analysis',
       author='Lionel London',
       author_email='lionel.london@ligo.org',
-      packages=['nrutils'],
+      packages=find_packages(),
       url='https://github.com/llondon6/nrutils',
       download_url='https://github.com/llondon6/nrutils/archive/master.zip',
      )


### PR DESCRIPTION
@llondon6 I've updated setup.py with a method that I have used before ([`dadownloader/setup.py#L9`](https://github.com/Galadirith/dadownloader/blob/master/setup.py#L9)) that automatically finds and installs all sub-packages. Hopefully this will fix https://github.com/llondon6/nrutils_dev/issues/1#issuecomment-207960957 @Cyberface. It requires [`setuptools`](https://pypi.python.org/pypi/setuptools) however thats a requirement for `pip` so you will have it already. 

I've also updated `.gitignore` as as it wasn't catching the specified files for me, but please feel free to ignore my changes to `.gitignore` if it cause problems for you.

Thanks guys 😄 