### PR TITLE
Dev level map

### DIFF
--- a/nrutils/core/nrsc.py
+++ b/nrutils/core/nrsc.py
@@ -265,17 +265,18 @@ class scentry:
                 msg = 'The handler is found to have a "%s" method. Rather than the config file, this method will be used to determine the default extraction parameter and level.' % green(special_method)
                 alert(msg,'scentry.learn_metadata')
             # Estimate a good extraction radius and level for an input scentry object from the BAM catalog
-            this.default_extraction_par, this.default_level, this.extraction_map = handler.__dict__[special_method](this)
-            # NOTE: this.extraction_map is a dictionary that contains two maps. extraction_map['radius_map'] and extraction_map['level_map']
-            # extraction_map['radius_map'] maps the extraction radius number to the extraction radius in units of M
-            # extraction_map['level_map'] maps the extraction radius number to appropriate level number. This one only applies to BAM.
+            this.default_extraction_par, this.default_level, this.extraction_map_dict = handler.__dict__[special_method](this)
+            # NOTE: this.extraction_map_dict is a dictionary that contains two maps. extraction_map_dict['radius_map'] and extraction_map_dict['level_map']
+            # extraction_map_dict['radius_map'] maps the extraction radius number to the extraction radius in units of M
+            # extraction_map_dict['level_map'] maps the extraction radius number to appropriate level number. This one only applies to BAM.
         else:
             # NOTE that otherwise, values from the configuration file will be used
             this.default_extraction_par = this.config.default_par_list[0]
             this.default_level = this.config.default_par_list[1]
-            this.extraction_map['radius_map'] = None
-            this.extraction_map['level_map'] = None
-            # NOTE: this.extraction_map is a dictionary that contains two maps. extraction_map['radius_map'] and extraction_map['level_map']
+            this.extraction_map_dict = {}
+            this.extraction_map_dict['radius_map'] = None
+            this.extraction_map_dict['level_map'] = None
+            # NOTE: this.extraction_map_dict is a dictionary that contains two maps. extraction_map_dict['radius_map'] and extraction_map_dict['level_map']
             # The default values are to set these to None.
 
         # Basic sanity check for standard attributes. NOTE this section needs to be completed and perhaps externalized to the current function.

--- a/nrutils/core/nrsc.py
+++ b/nrutils/core/nrsc.py
@@ -265,14 +265,18 @@ class scentry:
                 msg = 'The handler is found to have a "%s" method. Rather than the config file, this method will be used to determine the default extraction parameter and level.' % green(special_method)
                 alert(msg,'scentry.learn_metadata')
             # Estimate a good extraction radius and level for an input scentry object from the BAM catalog
-            this.default_extraction_par,this.default_level,this.extraction_radius_map = handler.__dict__[special_method](this)
-            # NOTE that and extraction_radius_map is also defined here, which allows referencing between extraction parameter and extaction radius
+            this.default_extraction_par, this.default_level, this.extraction_map = handler.__dict__[special_method](this)
+            # NOTE: this.extraction_map is a dictionary that contains two maps. extraction_map['radius_map'] and extraction_map['level_map']
+            # extraction_map['radius_map'] maps the extraction radius number to the extraction radius in units of M
+            # extraction_map['level_map'] maps the extraction radius number to appropriate level number. This one only applies to BAM.
         else:
             # NOTE that otherwise, values from the configuration file will be used
             this.default_extraction_par = this.config.default_par_list[0]
             this.default_level = this.config.default_par_list[1]
-            this.extraction_radius_map = None
-            # NOTE that and extraction_radius_map is also defined here, which allows referencing between extraction parameter and extaction radius, the dault value is currently None
+            this.extraction_map['radius_map'] = None
+            this.extraction_map['level_map'] = None
+            # NOTE: this.extraction_map is a dictionary that contains two maps. extraction_map['radius_map'] and extraction_map['level_map']
+            # The default values are to set these to None.
 
         # Basic sanity check for standard attributes. NOTE this section needs to be completed and perhaps externalized to the current function.
 

--- a/nrutils/handlers/bam.py
+++ b/nrutils/handlers/bam.py
@@ -259,9 +259,9 @@ def infer_default_level_and_extraction_parameter( this,     # An scentry object
 
     # Also store a dictionary between extraction parameter and extraction radius
     # And a dictionary between the level parameter and extraction radius
-    extraction_map = {}
-    extraction_map['radius_map'] = { exr[n]:r for n,r in enumerate(rad) }
-    extraction_map['level_map'] = { exr[n]:l for n,l in enumerate(lev) }
+    extraction_map_dict = {}
+    extraction_map_dict['radius_map'] = { exr[n]:r for n,r in enumerate(rad) }
+    extraction_map_dict['level_map'] = { exr[n]:l for n,l in enumerate(lev) }
 
     # Return answers
-    return extraction_parameter,level,extraction_map
+    return extraction_parameter,level,extraction_map_dict

--- a/nrutils/handlers/bam.py
+++ b/nrutils/handlers/bam.py
@@ -258,7 +258,10 @@ def infer_default_level_and_extraction_parameter( this,     # An scentry object
     extraction_parameter,level = exr[k],lev[k]
 
     # Also store a dictionary between extraction parameter and extraction radius
-    extraction_radius_map = { exr[n]:r for n,r in enumerate(rad) }
+    # And a dictionary between the level parameter and extraction radius
+    extraction_map = {}
+    extraction_map['radius_map'] = { exr[n]:r for n,r in enumerate(rad) }
+    extraction_map['level_map'] = { exr[n]:l for n,l in enumerate(lev) }
 
     # Return answers
-    return extraction_parameter,level,extraction_radius_map
+    return extraction_parameter,level,extraction_map

--- a/nrutils/handlers/maya.py
+++ b/nrutils/handlers/maya.py
@@ -242,12 +242,12 @@ def infer_default_level_and_extraction_parameter( this,     # An scentry object
     # Also store a dictionary between extraction parameter and extraction radius
     # And a dictionary between the level parameter and extraction radius.
     # For Maya this is not used and so it's set to None. BAM uses it though.
-    extraction_map = {}
-    extraction_map['radius_map'] = { exr[n]:r for n,r in enumerate(rad) }
-    extraction_map['level_map'] = None
+    extraction_map_dict = {}
+    extraction_map_dict['radius_map'] = { exr[n]:r for n,r in enumerate(rad) }
+    extraction_map_dict['level_map'] = None
 
     # Note that maya sims have no level specification
     level = None
 
     # Return answers
-    return extraction_parameter,level,extraction_map
+    return extraction_parameter,level,extraction_map_dict

--- a/nrutils/handlers/maya.py
+++ b/nrutils/handlers/maya.py
@@ -240,10 +240,14 @@ def infer_default_level_and_extraction_parameter( this,     # An scentry object
     extraction_parameter = exr[k]
 
     # Also store a dictionary between extraction parameter and extraction radius
-    extraction_radius_map = { exr[n]:r for n,r in enumerate(rad) }
+    # And a dictionary between the level parameter and extraction radius.
+    # For Maya this is not used and so it's set to None. BAM uses it though.
+    extraction_map = {}
+    extraction_map['radius_map'] = { exr[n]:r for n,r in enumerate(rad) }
+    extraction_map['level_map'] = None
 
     # Note that maya sims have no level specification
     level = None
 
     # Return answers
-    return extraction_parameter,level,extraction_radius_map
+    return extraction_parameter,level,extraction_map


### PR DESCRIPTION
So when making BAM h5 files I want to make sure that I use the largest available extraction radius.

This was basically impossible to do because the information about what the 'level' for a given extraction radius was, was not available.

This PR changes this. It modifies the BAM and MAYA handler to return an extraction_map_dictionary that has the same information about the extraction radius as before but also has the same thing but for the level. Note that MAYA doesn't actually use this so it's just set to None but has the same structure for homogeneity reasons.

Can you check if you are happy with this Lionel? Then merge? Thanks!